### PR TITLE
remove note about adding an extra level /cms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ You can access CMS REST API documentation from one of the following:
 
 **Important:** 
 - In a classic version of UCMDB, make sure you add **/rest-api** to the beginning of the URL, so that it becomes **/rest-api/authenticate**.
-- In a suite version, make sure you add **/ucmdb-server/rest-api** to the beginning of the URL, so that it becomes **/ucmdb-server/rest-api/authenticate**. 
-
-  For SMAX suite, a further root context **/cms** needs to be added, which results in **/cms/ucmdb-server/rest-api/authenticate**.
-
-
+- In a suite version, make sure you add **/ucmdb-server/rest-api** to the beginning of the URL, so that it becomes **/ucmdb-server/rest-api/authenticate**.
 
 ## Set up the sample project
 


### PR DESCRIPTION
Remove note about adding an extra level "/cms" to the SMAX suite enviroment as CMS embedded in SMAX is deprecated in SMAX 2020.08, and will be obsoleted in 2021.08